### PR TITLE
set default admin email to admin@cpantesters

### DIFF
--- a/lib/CPAN/Testers/Data/Generator.pm
+++ b/lib/CPAN/Testers/Data/Generator.pm
@@ -59,7 +59,8 @@ CPAN Testers Server.
 ';
 
 my @admins = (
-    'barbie@missbarbell.co.uk',
+    'webmaster@cpantesters.org',
+    #'barbie@missbarbell.co.uk',
     #'david@dagolden.com'
 );
 
@@ -95,6 +96,9 @@ sub new {
 
     if($cfg->SectionExists('ADMINISTRATION')) {
         my @admins = $cfg->val('ADMINISTRATION','admins');
+        $self->{admins} = \@admins;
+    }
+    else {
         $self->{admins} = \@admins;
     }
 


### PR DESCRIPTION
This will ensure the failure e-mails for invalid Metabase reports are
sent even if there's no configuration saying where to send them.

This might start spamming us, but we'll work through the issues as it
happens.

---

I checked all the config files on the server, and none of them seem to set the `ADMINISTRATION` section. So I'm not sure if we'd be getting any e-mail about invalid reports. This patch will ensure there's always a default, and that default is the admins mailing list.
